### PR TITLE
Improve name replacement handling

### DIFF
--- a/src/app/core/name-map.service.ts
+++ b/src/app/core/name-map.service.ts
@@ -74,9 +74,9 @@ export class NameMapService {
       // Escape special regex characters in the search string
       const escapedFrom = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-      // Match whole words with various surrounding punctuation
-      const re = new RegExp(`(^|[\\s"'([{<])${escapedFrom}(?=[\\s"'\\])}>,.]|$)`, 'g');
-      result = result.replace(re, `$1${to}`);
+      // Simple global replacement of the exact name
+      const re = new RegExp(escapedFrom, 'g');
+      result = result.replace(re, to);
     });
 
     return result;

--- a/tests/name-map.service.spec.ts
+++ b/tests/name-map.service.spec.ts
@@ -15,6 +15,31 @@ describe('NameMapService', () => {
     expect(result).toMatch(/BRAVO-1/);
   });
 
+  it('handles punctuation around names', () => {
+    const text = 'Alice, Bob! Are you there?';
+    const sanitized = service.sanitize(text, ['Alice', 'Bob']);
+    expect(sanitized).toMatch(/ALFA-1,/);
+    expect(sanitized).toMatch(/BRAVO-1!/);
+  });
+
+  it('handles nested names correctly', () => {
+    const text = 'Ann and Anna went home.';
+    const sanitized = service.sanitize(text, ['Ann', 'Anna']);
+    expect(sanitized).toMatch(/ALFA-1 and BRAVO-1/);
+  });
+
+  it('sanitizes names with punctuation and no surrounding spaces', () => {
+    const text = 'GAGoldring, Alice (DOES)1 hour.';
+    const sanitized = service.sanitize(text, ['Goldring, Alice (DOES)']);
+    expect(sanitized).toContain('GAALFA-11 hour.');
+  });
+
+  it('sanitizes names followed by numbers', () => {
+    const text = 'AJ McClary1:18:40';
+    const sanitized = service.sanitize(text, ['AJ McClary']);
+    expect(sanitized).toContain('ALFA-11:18:40');
+  });
+
   it('restores names', () => {
     service.sanitize('Alice met Bob.', ['Alice', 'Bob']);
     const restored = service.restore('ALFA-1 met BRAVO-1.');


### PR DESCRIPTION
## Summary
- simplify regex in `NameMapService.applyMapping`
- add tests for complex names including commas and numbers

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: connect EHOSTUNREACH)*