### PR TITLE
Improve name sanitization regex and add offline tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+# Compile TypeScript test sources
+tsc -p tsconfig.test.json
+# Adjust module paths for compiled service
+sed -i 's#require("@angular/core")#require("../../../test_stubs/angular-core")#' dist-test/src/app/core/name-map.service.js
+sed -i 's#require("rxjs")#require("../../../test_stubs/rxjs")#' dist-test/src/app/core/name-map.service.js
+# Run tests
+node dist-test/tests/name-map.service.spec.js
+node dist-test/tests/codename-generator.spec.js

--- a/src/app/core/name-map.service.ts
+++ b/src/app/core/name-map.service.ts
@@ -74,8 +74,11 @@ export class NameMapService {
       // Escape special regex characters in the search string
       const escapedFrom = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-      // Match whole words with various surrounding punctuation
-      const re = new RegExp(`(^|[\\s"'([{<])${escapedFrom}(?=[\\s"'\\])}>,.]|$)`, 'g');
+      // Match whole words with generic non-alphanumeric boundaries
+      const re = new RegExp(
+        `(^|[^A-Za-z0-9])${escapedFrom}(?=[^A-Za-z0-9]|$)`,
+        'g'
+      );
       result = result.replace(re, `$1${to}`);
     });
 

--- a/test_stubs/angular-core.ts
+++ b/test_stubs/angular-core.ts
@@ -1,0 +1,3 @@
+export function Injectable(_?: any): ClassDecorator {
+  return () => {};
+}

--- a/test_stubs/assert.d.ts
+++ b/test_stubs/assert.d.ts
@@ -1,0 +1,7 @@
+declare module 'assert' {
+  function ok(value: any, message?: string): void;
+  namespace ok {
+    function strictEqual(actual: any, expected: any): void;
+  }
+  export = ok;
+}

--- a/test_stubs/node-globals.d.ts
+++ b/test_stubs/node-globals.d.ts
@@ -1,0 +1,2 @@
+declare var process: { exitCode?: number };
+declare var global: any;

--- a/test_stubs/rxjs.ts
+++ b/test_stubs/rxjs.ts
@@ -1,0 +1,7 @@
+export class BehaviorSubject<T> {
+  private _value: T;
+  constructor(value: T) { this._value = value; }
+  get value(): T { return this._value; }
+  asObservable() { return this; }
+  next(val: T): void { this._value = val; }
+}

--- a/tests/codename-generator.spec.ts
+++ b/tests/codename-generator.spec.ts
@@ -1,12 +1,32 @@
+import assert from 'assert';
 import { CodenameGenerator } from '../src/app/core/codename-generator';
 
-describe('CodenameGenerator', () => {
-  it('produces unique codes', () => {
-    const gen = new CodenameGenerator();
+function run() {
+  let gen: CodenameGenerator;
+
+  function beforeEach() {
+    gen = new CodenameGenerator();
+  }
+
+  function test(desc: string, fn: () => void) {
+    try {
+      beforeEach();
+      fn();
+      console.log('✓', desc);
+    } catch (err) {
+      console.error('✗', desc);
+      console.error(err);
+      process.exitCode = 1;
+    }
+  }
+
+  test('produces unique codes', () => {
     const codes = new Set<string>();
     for (let i = 0; i < 30; i++) {
       codes.add(gen.getNext(Array.from(codes)));
     }
-    expect(codes.size).toBe(30);
+    assert.strictEqual(codes.size, 30);
   });
-});
+}
+
+run();

--- a/tests/name-map.service.spec.ts
+++ b/tests/name-map.service.spec.ts
@@ -1,23 +1,59 @@
+import assert from 'assert';
 import { NameMapService } from '../src/app/core/name-map.service';
 
-describe('NameMapService', () => {
+function run() {
+  // Setup a simple localStorage mock
+  (global as any).localStorage = {
+    data: {} as Record<string, string>,
+    getItem(key: string) { return this.data[key] ?? null; },
+    setItem(key: string, value: string) { this.data[key] = value; },
+    removeItem(key: string) { delete this.data[key]; }
+  };
+
   let service: NameMapService;
 
-  beforeEach(() => {
+  function beforeEach() {
     service = new NameMapService();
     service.reset();
-  });
+  }
 
-  it('generates codenames for names', () => {
+  function test(desc: string, fn: () => void) {
+    try {
+      beforeEach();
+      fn();
+      console.log('✓', desc);
+    } catch (err) {
+      console.error('✗', desc);
+      console.error(err);
+      process.exitCode = 1;
+    }
+  }
+
+  test('generates codenames for names', () => {
     const text = 'Alice met Bob.';
     const result = service.sanitize(text, ['Alice', 'Bob']);
-    expect(result).toMatch(/ALFA-1/);
-    expect(result).toMatch(/BRAVO-1/);
+    assert(/ALFA-1/.test(result));
+    assert(/BRAVO-1/.test(result));
   });
 
-  it('restores names', () => {
+  test('handles punctuation around names', () => {
+    const text = 'Alice, Bob! Are you there?';
+    const sanitized = service.sanitize(text, ['Alice', 'Bob']);
+    assert(/ALFA-1,/.test(sanitized));
+    assert(/BRAVO-1!/.test(sanitized));
+  });
+
+  test('handles nested names correctly', () => {
+    const text = 'Ann and Anna went home.';
+    const sanitized = service.sanitize(text, ['Ann', 'Anna']);
+    assert(/ALFA-1 and BRAVO-1/.test(sanitized));
+  });
+
+  test('restores names', () => {
     service.sanitize('Alice met Bob.', ['Alice', 'Bob']);
     const restored = service.restore('ALFA-1 met BRAVO-1.');
-    expect(restored).toBe('Alice met Bob.');
+    assert.strictEqual(restored, 'Alice met Bob.');
   });
-});
+}
+
+run();

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "dist-test",
+    "rootDir": ".",
+    "baseUrl": "./",
+    "paths": {
+      "@angular/core": ["./test_stubs/angular-core"],
+      "rxjs": ["./test_stubs/rxjs"]
+    },
+    "skipLibCheck": true,
+    "types": [],
+    "typeRoots": [],
+    "importHelpers": false
+  },
+  "include": [
+    "src/app/core/name-map.service.ts",
+    "tests/**/*.spec.ts",
+    "test_stubs/**/*.ts",
+    "test_stubs/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- replace regex with simpler non-alphanumeric boundary check
- convert specs to a minimal Node-based runner
- add stubs and config for offline testing
- add script `run-tests.sh` to compile and run tests without network

## Testing
- `./run-tests.sh`