### PR TITLE
Improve test coverage

### DIFF
--- a/tests/codename-generator.spec.ts
+++ b/tests/codename-generator.spec.ts
@@ -9,4 +9,10 @@ describe('CodenameGenerator', () => {
     }
     expect(codes.size).toBe(30);
   });
+
+  it('avoids collisions with existing codes', () => {
+    const gen = new CodenameGenerator();
+    const code = gen.getNext(['ALFA-1']);
+    expect(code).toBe('ALFA-1-1');
+  });
 });

--- a/tests/name-map.service.spec.ts
+++ b/tests/name-map.service.spec.ts
@@ -45,4 +45,10 @@ describe('NameMapService', () => {
     const restored = service.restore('ALFA-1 met BRAVO-1.');
     expect(restored).toBe('Alice met Bob.');
   });
+
+  it('reset clears stored mappings', () => {
+    service.sanitize('Alice met Bob.', ['Alice', 'Bob']);
+    service.reset();
+    expect(localStorage.getItem('namedropper-mappings')).toBe('[]');
+  });
 });


### PR DESCRIPTION
## Summary
- extend CodenameGenerator spec to check collisions
- expand NameMapService test to ensure reset clears localStorage

## Testing
- `npm test` *(fails: ng not found)*