### PR TITLE
Update README and UI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,27 +57,21 @@ npm start
 
 The app will be available at `http://localhost:4200/`
 
-## Deployment
+## Usage
 
-This application is configured to automatically deploy to GitHub Pages when changes are pushed to the main branch. The deployment process:
+### 🧑‍🤝‍🧑 Copy Attendee Names in Microsoft Teams
 
-1. Builds the application with production configuration
-2. Sets the correct base href for GitHub Pages (`/NameDropper/`)
-3. Deploys the built files to the `gh-pages` branch
+1. Open the Teams Calendar and locate your meeting.
+2. Click the ellipsis (…) next to the event name.
+3. Select "Copy Attendee Names" from the dropdown.
+4. Paste anywhere (e.g., email, document) to view the list.
 
-### Manual Deployment
+### 📄 Copy Transcript from Meeting Recap
 
-If you need to deploy manually:
-
-```bash
-# Build for GitHub Pages
-npm run build:gh-pages
-
-# Deploy (requires push access to the repository)
-npm run deploy
-```
-
-The application will be available at: `https://ajmccllary.github.io/NameDropper/`
+1. Open the Teams Calendar and click on the past meeting.
+2. Scroll to the Recap tab.
+3. Under Transcript, click the "Copy" icon or highlight and right-click > Copy.
+4. Paste into any text editor or document.
 
 ## Use Cases
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -18,6 +18,15 @@
     </mat-card-header>
     <mat-card-content>
       <app-transcript-input></app-transcript-input>
+      <div class="instructions">
+        <h3>🧑‍🤝‍🧑 Copy Attendee Names in Microsoft Teams</h3>
+        <ol>
+          <li>Open the Teams Calendar and locate your meeting.</li>
+          <li>Click the ellipsis (…) next to the event name.</li>
+          <li>Select "Copy Attendee Names" from the dropdown.</li>
+          <li>Paste anywhere (e.g., email, document) to view the list.</li>
+        </ol>
+      </div>
     </mat-card-content>
   </mat-card>
 
@@ -31,6 +40,15 @@
     </mat-card-header>
     <mat-card-content>
       <app-sanitized-view></app-sanitized-view>
+      <div class="instructions">
+        <h3>📄 Copy Transcript from Meeting Recap</h3>
+        <ol>
+          <li>Open the Teams Calendar and click on the past meeting.</li>
+          <li>Scroll to the Recap tab.</li>
+          <li>Under Transcript, click the "Copy" icon or highlight and right-click &gt; Copy.</li>
+          <li>Paste into any text editor or document.</li>
+        </ol>
+      </div>
     </mat-card-content>
   </mat-card>
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -30,6 +30,10 @@
   }
 }
 
+.instructions {
+  margin-top: 16px;
+}
+
 mat-toolbar {
   mat-icon {
     margin-right: 8px;


### PR DESCRIPTION
## Summary
- clean up README deployment section
- add new "Usage" steps for Microsoft Teams
- show Teams instructions in the interface

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm test` *(fails: ng not found)*